### PR TITLE
Copy cgroup file on computes.

### DIFF
--- a/roles/openmpi/tasks/infiniband.yml
+++ b/roles/openmpi/tasks/infiniband.yml
@@ -1,0 +1,12 @@
+- name: "package █ Install libverbs"
+  package:
+    name: libibverbs-devel
+    state: present
+  tags:
+    - package
+
+- name: Allow openmpi to work with Infiniband
+  ansible.builtin.lineinfile:
+    path: ~/.bashrc
+    line: "export OMPI_MCA_btl_openib_allow_ib=1"
+    create: yes

--- a/roles/openmpi/tasks/main.yml
+++ b/roles/openmpi/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: include_vars ░ Gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}.yml"
+        - "vars/{{ ansible_facts.os_family }}.yml"
+      skip: true
+  tags:
+    - always
+
+- name: "package █ Install {{ openmpi_packages_to_install[openmpi_profile] | join(' ') }}"
+  package:
+    name: "{{ openmpi_packages_to_install[openmpi_profile] }}"
+    state: present
+  tags:
+    - package
+
+- name: service █ Manage openmpi service state
+  service:
+    name: openmpi
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+    state: "{{ (start_services | bool) | ternary('started', omit) }}"
+  tags:
+    - service
+
+- name: include_tasks ░ Configure openmpi with Infiniband
+  include_tasks: "infiniband.yml"
+  when:  openmpi_profile == "server" and install_infiniband == 'True'

--- a/roles/openmpi/vars/RedHat_8.yml
+++ b/roles/openmpi/vars/RedHat_8.yml
@@ -1,0 +1,8 @@
+---
+slurm_packages_to_install:
+  server:
+  - openmpi
+  - openmpi-devel
+
+  client:
+  - openmpi

--- a/roles/openmpi/vars/main.yml
+++ b/roles/openmpi/vars/main.yml
@@ -1,0 +1,2 @@
+---
+openmpi_role_version: 1.0.0

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -12,6 +12,14 @@
   tags:
     - firewall
 
+- name: "copy █ Copy cgroup.conf to {{ slurm_home_path }}/cgroup.conf"
+  copy:
+    src: cgroup.conf
+    dest: "{{ slurm_home_path }}/cgroup.conf"
+    owner: slurm
+    group: slurm
+    mode: 0644
+
 - name: include_tasks ░ Deploy Slurm compute configuration
   include_tasks: "compute_{{ slurm_computes_config }}.yml"
 


### PR DESCRIPTION
Copy the cgroup file on the computes:

```
slurmd: debug3: Trying to load plugin /usr/lib64/slurm/proctrack_cgroup.so
slurmd: debug2: _read_slurm_cgroup_conf_int: No cgroup.conf file (/etc/slurm/cgroup.conf)
slurmd: debug2: _file_read_content: unable to open '(null)/freezer//tasks' for reading : No such file or directory
slurmd: debug2: xcgroup_get_param: unable to get parameter 'tasks' for '(null)/freezer/'
slurmd: error: cgroup namespace 'freezer' not mounted. aborting
slurmd: error: unable to create freezer cgroup namespace
slurmd: error: Couldn't load specified plugin name for proctrack/cgroup: Plugin init() callback failed
slurmd: error: cannot create proctrack context for proctrack/cgroup
slurmd: error: slurmd initialization failed
[root@c001 ~]#
```
