### PR TITLE
Feat: update_reboot - role creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - report. Owner: @oxedions
   - singularity. Owner: @strus38
   - slurm. Owner: @oxedions
+  - update_reboot: Owner: @oxedions
   - users_basic. Owner: @oxedions
 
 ### Updated roles

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ While the core stack aims to be multiple Linux distributions ready, each Communi
 | report                | Check inventory and gather helpful data                  | @oxedions       | [link](roles/report/)               |
 | singularity           | Install and configure Singularity or SingularityPRO      | @strus38        | [link](roles/singularity/)          |
 | slurm                 | Install and configure Slurm Workload Manager             | @oxedions       | [link](roles/slurm/)                |
+| update_reboot         | Update all packages and reboot system                    | @oxedions       | [link](roles/update_reboot/)        |
 | users_basic           | Set / remove users                                       | @oxedions       | [link](roles/users_basic/)          |
 
 ## List of external useful roles/tools

--- a/roles/update_reboot/README.md
+++ b/roles/update_reboot/README.md
@@ -1,0 +1,26 @@
+# Update & Reboot
+
+## Description
+
+This role simply allows to update all packages on system and then reboot
+to ensure system is fully upgraded, including kernel running.
+Can be useful to be run after `repositories_client` role from CORE in a playbook.
+The role will wait for host to come back after reboot, allowing playbook to
+continue to execute after system is rebooted.
+
+## Instructions
+
+By default, the role will do nothing.
+
+To trigger packages update, you need to set `update_reboot_upgrade_packages` to
+`true`.
+
+To Trigger reboot, you need to set `update_reboot_reboot` to `true`.
+
+It is also possible to ajust the reboot timeout value, for very slow systems,
+using variable `update_reboot_reboot_timeout`. By default, this variable is set
+to `600`, which means `600s -> 600/60=10 minutes`.
+
+## Changelog
+
+* 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/update_reboot/defaults/main.yml
+++ b/roles/update_reboot/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+update_reboot_upgrade_packages: false
+update_reboot_reboot: false
+update_reboot_reboot_timeout: 600

--- a/roles/update_reboot/tasks/main.yml
+++ b/roles/update_reboot/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: package █ Upgrade all packages
+  package:
+    name: "*"
+    state: latest
+  when: update_reboot_upgrade_packages
+
+- name: Reboot a slow machine that might have lots of updates to apply
+  reboot:
+    reboot_timeout: "{{ update_reboot_reboot_timeout }}"
+  when: update_reboot_reboot


### PR DESCRIPTION
Simply allows to work on upgraded systems during playbook execution.