### PR TITLE
Fix: podman - correct logical operator to run local registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - slurm: major role upgrade. (#11)
   - users_basic: add ssh public keys support. (#12)
   - prometheus: correct default value of prometheus_exporters_groups_to_scrape. (#30)
+  - podman: correct logical operator to run local registry. (#33)
 
 ### New tools
 

--- a/roles/podman/tasks/registry.yml
+++ b/roles/podman/tasks/registry.yml
@@ -25,4 +25,4 @@
 - name: registry █ Run local registry
   command: "podman run --privileged -d --name registry -p 5000:{{ podman_local_registry_port }} -v /var/lib/registry:{{ podman_local_registry_dir }} --restart=always {{ podman_registry_container }}:{{ podman_registry_container_tag }}"
   # yamllint disable-line rule:line-length
-  when: cmdout is not defined | cmdout.rc != 0
+  when: cmdout is not defined or cmdout.rc != 0


### PR DESCRIPTION
Hello, I tried the podman role today, and got two errors. Here is the first error:

```
TASK [podman : registry █ Run local registry] ****************************************************************************
Tuesday 19 October 2021  18:56:04 +0200 (0:00:00.514)       0:00:11.929 *******
fatal: [management1]: FAILED! =>
  msg: |-
    The conditional check 'cmdout is not defined | cmdout.rc != 0' failed. The error was: template error while templating string: no filter named 'cmdout.rc'. String: {% if cmdout is not defined | cmdout.rc != 0 %} True {% else %} False {% endif %}

    The error appears to be in '/etc/bluebanquise/roles/community/podman/tasks/registry.yml': line 25, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:


    - name: registry █ Run local registry
      ^ here
```

I am using ansible 2.11, maybe this error only shows up for that version? But the fix should work for 2.9+.
This PR will fix the error when the registry has not been deployed yet, it also skips the task when the registry has been deployed.
Also adding @strus38 in the loop to check it out. 