### PR TITLE
Feat: podman - use systemd service to manage registry

### DIFF
--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -16,6 +16,14 @@ This role is compatible with HA clusters:
 
 Ansible 2.7 or higher is required for defaults/main/*.yml to work correctly.
 
+## Known Limitations
+
+When firewalld is running, containers deployed with podman may lose connectivity if the firewall rules are reloaded with the `firewall-cmd --reload` command, due to non-persistent rules added by podman being lost. As a workaround, the following command should be used after reloading the firewall, it will restore container connectivity without having to re-deploy the containers:
+
+```
+podman network reload --all
+```
+
 ## Variables
 
 Variables for this role:

--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -4,7 +4,7 @@ Ansible role for setting up [podman](https://podman.io) in Bluebanquise environm
 
 This role is compatible with HA clusters:
 * For active/active configuration please refer to the documentation since you need create 'bundles' to launch your containers: [How to create pacemaker container bundles using podman](https://access.redhat.com/solutions/3871591).
-* For active/passive cluster
+* For active/passive cluster, it is possible to use systemd services to launch containers, and then use pacemaker to manage the systemd containers. An example of this is the registry container deployed by this role. Note that the clients of the registry should use a virtual IP address managed by pacemaker.
 
 ## Supported Platforms
 

--- a/roles/podman/tasks/registry.yml
+++ b/roles/podman/tasks/registry.yml
@@ -16,6 +16,17 @@
   command: "podman load -i {{ podman_registry_container_path }}"
   changed_when: false
 
+- name: firewalld █ "Add registry port to firewall's {{ ha_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ ha_firewall_zone | default('public') }}"
+    port: "{{ podman_local_registry_port }}/tcp"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when: ep_firewall | default(false) | bool
+  tags:
+    - firewall
+
 - name: template █ Install registry service file
   template:
     src: registry.service.j2

--- a/roles/podman/tasks/registry.yml
+++ b/roles/podman/tasks/registry.yml
@@ -16,13 +16,27 @@
   command: "podman load -i {{ podman_registry_container_path }}"
   changed_when: false
 
-- name: registry █ Find out if registry is already deployed
-  command: "podman container exists {{ podman_registry_container }}"
-  register: cmdout
-  changed_when: false
-  failed_when: false
+- name: template █ Install registry service file
+  template:
+    src: registry.service.j2
+    dest: /etc/systemd/system/registry.service
+    owner: root
+    group: root
+    force: yes
+    mode: 0655
+  tags:
+    - service
 
-- name: registry █ Run local registry
-  command: "podman run --privileged -d --name registry -p 5000:{{ podman_local_registry_port }} -v /var/lib/registry:{{ podman_local_registry_dir }} --restart=always {{ podman_registry_container }}:{{ podman_registry_container_tag }}"
-  # yamllint disable-line rule:line-length
-  when: cmdout is not defined or cmdout.rc != 0
+- name: systemd █ Reload systemd
+  systemd:
+    daemon_reload: yes
+  tags:
+    - service
+
+- name: service █ Manage registry state
+  service:
+    name: registry
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+    state: "{{ (start_services | bool) | ternary('started', omit) }}"
+  tags:
+    - service

--- a/roles/podman/templates/registry.service.j2
+++ b/roles/podman/templates/registry.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=registry container
+
+[Service]
+Restart=always
+ExecStart=/usr/bin/podman run --name=registry --rm --privileged -p 5000:{{ podman_local_registry_port }} -v /var/lib/registry:{{ podman_local_registry_dir }} {{ podman_registry_container }}:{{ podman_registry_container_tag }}
+ExecStop=/usr/bin/podman stop -t 5 registry
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/podman/templates/registry.service.j2
+++ b/roles/podman/templates/registry.service.j2
@@ -1,10 +1,19 @@
 [Unit]
-Description=registry container
+Description=registry.service
+Wants=network-online.target
+After=network-online.target
+RequiresMountsFor=%t/containers
 
 [Service]
-Restart=always
-ExecStart=/usr/bin/podman run --name=registry --rm --privileged -p 5000:{{ podman_local_registry_port }} -v /var/lib/registry:{{ podman_local_registry_dir }} {{ podman_registry_container }}:{{ podman_registry_container_tag }}
-ExecStop=/usr/bin/podman stop -t 5 registry
+Environment=PODMAN_SYSTEMD_UNIT=%n
+Restart=on-failure
+TimeoutStopSec=62
+ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --sdnotify=conmon --cgroups=no-conmon --rm --replace --name=registry --privileged -p 5000:{{ podman_local_registry_port }} -v /var/lib/registry:{{ podman_local_registry_dir }} {{ podman_registry_container }}:{{ podman_registry_container_tag }}
+ExecStop=/usr/bin/podman stop -t 2 --ignore --cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+Type=notify
+NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target default.target


### PR DESCRIPTION
This PR is for a feature request to use systemd to manage the podman registry. The goal is to support an active/passive configuration for the registry in a HA cluster environment.

The original implementation works and would be usable in an active/active scenario as the README proposes. However there is a detail: when using this approach, each container will get its own volume mount (see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/high_availability_add-on_reference/s1-containers-haar#s3-bundlestorage-properties-HAAR , I could not find this documentation for RHEL 8), meaning that the volume data is not shared by the instances. This may be fine for some services, but for registry I think it is best to push images once and have them available on the whole HA cluster.

With this PR, the registry could be managed by the high_availability role like this:

```
    - group: registry
      resources:
        - id: fs-registry
          type: Filesystem
          arguments: "device='/dev/registry' directory='{{ podman_local_registry_dir }}' fstype='ext4'"
        - id: vip-registry
          type: IPaddr2
          arguments: "ip={{ podman_local_registry_host }} cidr_netmask=255.255.0.0"
        - id: service-registry
          type: systemd:registry
          
```

(I did not consider adding this last bit to the podman README when I opened the PR, what do you think?)

Note: I have already tested the PR with a very similar HA configuration in a virtual cluster, and it works (registry can be relocated to a different node). The difference in the test is that I declared podman_local_registry_host with a variable from network.yml, and the pcs resource used the same variable definition. Also there was no Filesystem resource, but this example  follows the high_availability README.