### PR TITLE
Add Loki support

### DIFF
--- a/roles/loki/README.md
+++ b/roles/loki/README.md
@@ -1,0 +1,50 @@
+# Loki
+
+## Description
+
+This role configures Loki and Promtail on a BlueBanquise management node.
+
+A rsyslog forwarder configuration file is created to forward all rsyslog traffic to Promtail. From here Promtail uses Loki to store the data.
+
+The following labels are added to the syslog data:
+
+- app
+- host
+- job
+- level
+
+Further details about Loki and Promtail can be found at: https://grafana.com/docs/loki/latest
+
+Loki can be set as a data source in Grafana by setting the data source URL to http://localhost:3100.
+
+## Requirements
+
+loki and promtail RPMs are required.
+
+## Role Variables
+
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in table below.
+
+| Name | Default Value | Description |
+| ---- | ------------- | ----------- |
+| loki_groups                 | See `defaults/main.yml`    | Dictionary of groups to create                                            |
+| loki_users                  | See `defaults/main.yml`    | Dictionary of users to create                                             |
+| loki_conf_dir               | /etc/loki                  | Loki config directory                                                     |
+| loki_data_dir               | /var/lib/loki              | Loki data directory                                                       |
+| loki_index_dir              | {{ loki_data_dir }}/index  | Loki index directory                                                      |
+| loki_chunks_dir             | {{ loki_data_dir }}/chunks | Loki chunks directory                                                     |
+| loki_ip                     | 127.0.0.1                  | Loki HTTP IP address                                                      |
+| loki_port                   | 3100                       | Loki HTTP port                                                            |
+| loki_grpc_port              | 9095                       | Loki gRPC port                                                            |
+| loki_promtail_conf_dir      | /etc/promtail              | Promtail config dir                                                       |
+| loki_promtail_enable_server | false                      | Enable Promtail HTTP/gRPC server (not needed for processing central logs) |
+| loki_promtail_ip            | 127.0.0.1                  | Promtail HTTP/gRPC address                                                |
+| loki_promtail_port          | 9080                       | Promtail HTTP port                                                        |
+| loki_promtail_grpc_port     | 0                          | Set to zero to randomise gRPC port                                        |
+| loki_promtail_grpc_ip       | 127.0.0.1                  | Promtail gRPC address                                                     |
+| loki_promtail_syslog_port   | 1514                       | Syslog listener port                                                      |
+|loki_promtail_syslog_ip      | 127.0.0.1                  | Syslog address                                                            |
+
+## Change log
+
+* 1.0.0: Role creation. Neil Munday <neil@mundayweb.com>

--- a/roles/loki/defaults/main.yml
+++ b/roles/loki/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+
+loki_groups:
+  promtail:
+    gid: 461
+  loki:
+    gid: 462
+
+loki_users:
+  promtail:
+    uid: 461
+    group: promtail
+    home: /var/empty/promtail
+    comment: promtail user
+  loki:
+    uid: 462
+    group: loki
+    home: /var/empty/loki
+    comment: loki user
+
+loki_conf_dir: /etc/loki
+loki_data_dir: /var/lib/loki
+loki_index_dir: "{{ loki_data_dir }}/index"
+loki_chunks_dir: "{{ loki_data_dir }}/chunks"
+loki_ip: 127.0.0.1
+loki_port: 3100
+loki_grpc_port: 9095
+
+loki_promtail_conf_dir: /etc/promtail
+loki_promtail_enable_server: false
+loki_promtail_ip: 127.0.0.1
+loki_promtail_port: 9080
+loki_promtail_grpc_port: 0
+loki_promtail_grpc_ip: 127.0.0.1
+loki_promtail_syslog_port: 1514
+loki_promtail_syslog_ip: 127.0.0.1
+

--- a/roles/loki/handlers/main.yml
+++ b/roles/loki/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: service █ restart loki
+  service:
+    name: loki
+    state: restarted
+  listen: restart loki
+
+- name: service █ restart promtail
+  service:
+    name: promtail
+    state: restarted
+  listen: restart promtail

--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -1,0 +1,124 @@
+---
+
+- name: include_vars ░ Gather OS specific variables
+  # This task gathers variables defined in OS specific files.
+  #
+  # Search vars in:
+  #  - <distribution>_<major>.yml    # eg. CentOS_8.yml
+  #  - <os_family>_<major>.yml       # eg. RedHat_8.yml
+  #  - <distribution>.yml            # eg. CentOS.yml
+  #  - <os_family>.yml               # eg. RedHat.yml
+  #
+  # If no OS specific file is found, the role will default to vars/main.yml
+  #
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_version }}.yml"
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_version }}.yml"
+        - "vars/{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}.yml"
+        - "vars/{{ ansible_facts.os_family }}.yml"
+      skip: true
+  tags:
+    - always
+
+- name: include_tasks ░ Use OS dedicated firewall task
+  include_tasks: "{{ outer_item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_version }}/firewall.yml"
+        - "{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}/firewall.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}_{{ ansible_facts.distribution_version }}/firewall.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}/firewall.yml"
+        - "{{ ansible_facts.distribution | replace(' ','_') }}/firewall.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}/firewall.yml"
+      skip: true
+  loop_control:
+    loop_var: outer_item
+  tags:
+    - internal
+    - firewall
+
+- name: "package █ Install packages"
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - loki
+    - promtail
+
+# check for data dirs
+- name: "stat █ Check for {{ loki_data_dir }}"
+  stat:
+    path: "{{ loki_data_dir }}"
+  register: dir_rslt
+
+- name: "set_fact ░ Set period start date if {{ loki_data_dir }} does not exist"
+  set_fact:
+    loki_from_date: "{{ lookup('pipe', 'date +%Y-%m-%d') }}" 
+  when: not dir_rslt.stat.exists
+
+- name: "set_fact ░ Set period start date based on {{ loki_data_dir }} ctime"
+  set_fact:
+    loki_from_date: "{{ lookup('pipe', 'date -d @' + dir_rslt.stat.ctime|string + ' +%Y-%m-%d') }}"
+  when: dir_rslt.stat.exists
+
+- name: "template █ Configure loki"
+  template:
+    src: loki.yml.j2
+    dest: /etc/loki.yml
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart loki
+  tags:
+    - template
+
+- name: "file █ Create data dirs"
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: loki
+    group: loki
+    mode: "0700"
+  with_items:
+    - "{{ loki_data_dir }}"
+    - "{{ loki_chunks_dir }}"
+    - "{{ loki_index_dir }}"
+
+- name: "service █ Start and enable loki"
+  service:
+    name: loki
+    state: started
+    enabled: true
+
+- name: "template █ Configure promtail"
+  template:
+    src: promtail.yml.j2
+    dest: /etc/promtail.yml
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart promtail
+  tags:
+    - template
+
+- name: "template █ Add rsyslog forwarder"
+  template:
+    src: promtail-forward.conf.j2
+    dest: /etc/rsyslog.d/promtail-forward.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: service █ Restart rsyslog service
+  tags:
+    - template
+
+- name: "service █ Sta and enable promtail"
+  service:
+    name: promtail
+    state: started
+    enabled: true
+

--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -41,6 +41,26 @@
     - internal
     - firewall
 
+- name: "group █ Add user groups"
+  group:
+    gid: "{{ item.value.gid }}"
+    name: "{{ item.key }}"
+    state: present
+  with_dict: "{{ loki_groups }}"
+
+- name: "user █ Add users"
+  user:
+    name: "{{ item.key }}"
+    comment: "{{ item.value.comment | default(omit) }}"
+    group: "{{ item.value.group }}"
+    groups: "{{ item.value.groups | default(omit) }}"
+    create_home: "{{ item.value.create_home | default('yes') }}"
+    home: "{{ item.value.home | default(omit) }}"
+    shell: "{{ item.value.shell | default(omit) }}"
+    state: present
+    uid: "{{ item.value.uid }}"
+  with_dict: "{{ loki_users }}"
+
 - name: "package █ Install packages"
   package:
     name: "{{ item }}"
@@ -48,6 +68,38 @@
   with_items:
     - loki
     - promtail
+
+- name: "template █ Create /etc/systemd/system/loki.service"
+  template:
+    src: loki.service.j2
+    dest: /etc/systemd/system/loki.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart loki
+  register: loki_service_rslt
+
+- name: "template █ Create /etc/systemd/system/promtail.service"
+  template:
+    src: promtail.service.j2
+    dest: /etc/systemd/system/promtail.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart promtail
+  register: promtail_service_rslt
+
+- name: "command █ Reload systemd"
+  command: systemctl daemon-reload
+  when: loki_service_rslt.changed or promtail_service_rslt.changed
+
+- name: "file █ Create loki conf dir {{ loki_conf_dir }}"
+  file:
+    path: "{{ loki_conf_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
 
 # check for data dirs
 - name: "stat █ Check for {{ loki_data_dir }}"
@@ -68,10 +120,10 @@
 - name: "template █ Configure loki"
   template:
     src: loki.yml.j2
-    dest: /etc/loki.yml
+    dest: "{{ loki_conf_dir }}/loki.yml"
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   notify: restart loki
   tags:
     - template
@@ -94,10 +146,18 @@
     state: started
     enabled: true
 
+- name: "file █ create promtail conf dir {{ loki_promtail_conf_dir }}"
+  file:
+    path: "{{ loki_promtail_conf_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: "template █ Configure promtail"
   template:
     src: promtail.yml.j2
-    dest: /etc/promtail.yml
+    dest: "{{ loki_promtail_conf_dir }}/promtail.yml"
     owner: root
     group: root
     mode: "0644"
@@ -116,7 +176,7 @@
   tags:
     - template
 
-- name: "service █ Sta and enable promtail"
+- name: "service █ Start and enable promtail"
   service:
     name: promtail
     state: started

--- a/roles/loki/templates/loki.service.j2
+++ b/roles/loki/templates/loki.service.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Loki
+Documentation=https://grafana.com/docs/loki/latest
+After=network.target
+
+[Service]
+User=loki
+ExecStart=/usr/bin/loki -config.file {{ loki_conf_dir }}/loki.yml
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/loki/templates/loki.yml.j2
+++ b/roles/loki/templates/loki.yml.j2
@@ -1,0 +1,43 @@
+# {{ ansible_managed }}
+
+auth_enabled: false
+
+server:
+  http_listen_port: {{ loki_port }}
+
+ingester:
+  wal: 
+    enabled: true 
+    dir: /tmp/wal
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 5m
+  chunk_retain_period: 30s
+
+schema_config:
+  configs:
+  - from: {{ loki_from_date }}
+    store: boltdb
+    object_store: filesystem
+    schema: v11
+    index:
+      prefix: index_
+      period: 24h
+
+storage_config:
+  boltdb:
+    directory: "{{ loki_index_dir }}"
+
+  filesystem:
+    directory: "{{ loki_chunks_dir }}"
+
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+

--- a/roles/loki/templates/loki.yml.j2
+++ b/roles/loki/templates/loki.yml.j2
@@ -2,8 +2,11 @@
 
 auth_enabled: false
 
+
 server:
+  http_listen_address: {{ loki_ip }}
   http_listen_port: {{ loki_port }}
+  grpc_listen_port: {{ loki_grpc_port }}
 
 ingester:
   wal: 

--- a/roles/loki/templates/promtail-forward.conf.j2
+++ b/roles/loki/templates/promtail-forward.conf.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+action(type="omfwd" Target="127.0.0.1" protocol="tcp" port="{{ loki_promtail_syslog_port }}" Template="RSYSLOG_SyslogProtocol23Format" TCP_Framing="octet-counted" KeepAlive="on")

--- a/roles/loki/templates/promtail.service.j2
+++ b/roles/loki/templates/promtail.service.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Promtail
+Documentation=https://github.com/grafana/loki/blob/master/docs/clients/promtail/README.md
+After=network.target
+
+[Service]
+User=promtail
+ExecStart=/usr/bin/promtail -config.file {{ loki_promtail_conf_dir }}/promtail.yml
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/loki/templates/promtail.yml.j2
+++ b/roles/loki/templates/promtail.yml.j2
@@ -1,8 +1,15 @@
 # {{ ansible_managed }}
 
 server:
+{% if loki_promtail_enable_server %}
+  enable: true
   http_listen_port: {{ loki_promtail_port }}
-  grpc_listen_port: 0
+  http_listen_address: {{ loki_promtail_ip }}
+  grpc_listen_port: {{ loki_promtail_grpc_port }}
+  grpc_listen_address: {{ loki_promtail_grpc_ip }}
+{% else %}
+  disable: true
+{% endif %}
 
 positions:
   filename: /tmp/positions.yaml
@@ -13,7 +20,7 @@ clients:
 scrape_configs:
   - job_name: syslog
     syslog:
-      listen_address: 127.0.0.1:{{ loki_promtail_syslog_port }}
+      listen_address: {{ loki_promtail_syslog_ip }}:{{ loki_promtail_syslog_port }}
       idle_timeout: 120s
       label_structured_data: yes
       labels:

--- a/roles/loki/templates/promtail.yml.j2
+++ b/roles/loki/templates/promtail.yml.j2
@@ -1,0 +1,27 @@
+# {{ ansible_managed }}
+
+server:
+  http_listen_port: {{ loki_promtail_port }}
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://127.0.0.1:{{ loki_port }}/loki/api/v1/push
+
+scrape_configs:
+  - job_name: syslog
+    syslog:
+      listen_address: 127.0.0.1:{{ loki_promtail_syslog_port }}
+      idle_timeout: 120s
+      label_structured_data: yes
+      labels:
+        job: "syslog"
+    relabel_configs:
+      - source_labels: ['__syslog_message_hostname']
+        target_label: 'host'
+      - source_labels: ['__syslog_message_app_name']
+        target_label: 'app'
+      - source_labels: ['__syslog_message_severity']
+        target_label: 'level'

--- a/roles/loki/vars/main.yml
+++ b/roles/loki/vars/main.yml
@@ -1,0 +1,8 @@
+---
+loki_role_version: 1.0
+loki_data_dir: /opt/loki
+loki_index_dir: "{{ loki_data_dir }}/index"
+loki_chunks_dir: "{{ loki_data_dir }}/chunks"
+loki_port: 3100
+loki_promtail_port: 9080
+loki_promtail_syslog_port: 1514

--- a/roles/loki/vars/main.yml
+++ b/roles/loki/vars/main.yml
@@ -1,8 +1,2 @@
 ---
 loki_role_version: 1.0
-loki_data_dir: /opt/loki
-loki_index_dir: "{{ loki_data_dir }}/index"
-loki_chunks_dir: "{{ loki_data_dir }}/chunks"
-loki_port: 3100
-loki_promtail_port: 9080
-loki_promtail_syslog_port: 1514


### PR DESCRIPTION
This pull request adds Loki (and Promtail) support. The role is intended to be used on a management node that uses rsyslog as it will create a rsyslog forwarder config for Promtail to stream logs to Loki.

The Loki data source can then be configured in Grafana to create visualisations based on syslog data.

Note: loki and promtail RPMs are required. See: https://github.com/bluebanquise/infrastructure/pull/23 which adds these RPMs.