### PR TITLE
Fix: high_availability - Configure firewall before pcs commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Updated roles
 
+  - high_availability
+    - configure firewall before pcs commands. (#41)
+
   - podman: 
     - correct logical operator to run local registry. (#33)
     - quotes in lists of registries. (#34)

--- a/roles/high_availability/README.md
+++ b/roles/high_availability/README.md
@@ -556,4 +556,5 @@ not present. Then in HA resources, declare the following:
 
 ## 5. Changelog
 
+* 1.0.1: Configure firewall before pcs commands. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/high_availability/tasks/main.yml
+++ b/roles/high_availability/tasks/main.yml
@@ -36,6 +36,17 @@
   changed_when: False
   ignore_errors: yes
 
+- name: firewalld █ "Add services to firewall's {{ ha_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ ha_firewall_zone | default('public') }}"
+    service: high-availability
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when: ep_firewall | default(false) | bool
+  tags:
+    - firewall
+
 - name: Create cluster
   run_once: true
   delegate_to: "{{ high_availability_reference_node }}"
@@ -80,17 +91,6 @@
   loop:
     - corosync
     - pacemaker
-
-- name: firewalld █ "Add services to firewall's {{ ha_firewall_zone | default('public') }} zone"
-  firewalld:
-    zone: "{{ ha_firewall_zone | default('public') }}"
-    service: high-availability
-    immediate: "yes"
-    permanent: "yes"
-    state: enabled
-  when: ep_firewall | default(false) | bool
-  tags:
-    - firewall
 
 - name: Configure cluster
   run_once: true

--- a/roles/high_availability/vars/main.yml
+++ b/roles/high_availability/vars/main.yml
@@ -1,0 +1,2 @@
+---
+high_availability_role_version: 1.0.1


### PR DESCRIPTION
As the title indicates, the task to configure the firewall needs to run before the pcs commands, otherwise communication fails. So this PR is just to move the task.