### PR TITLE
Enable/disable STONITH when configuration is available/unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
   - high_availability
     - configure firewall before pcs commands. (#41)
+    - enable/disable STONITH when configuration is available/unavailable (#43)
 
   - podman: 
     - correct logical operator to run local registry. (#33)

--- a/roles/high_availability/README.md
+++ b/roles/high_availability/README.md
@@ -322,6 +322,8 @@ high_availability_stonith:
     avoids: ha1                                                        # Avoid resource to be running on own host
 ```
 
+If `high_availability_stonith` is not defined in the inventory, then this role will disable STONITH (stonith-enabled: false). This will allow the HA cluster to operate without STONITH (not recommended for production). Adding the `high_availability_stonith` variable will enable STONITH again.
+
 ## 3. Deploy HA
 
 The HA cluster is expected to have an active-passive configuration.
@@ -556,5 +558,6 @@ not present. Then in HA resources, declare the following:
 
 ## 5. Changelog
 
+* 1.0.2: Enable/disable STONITH when configuration is available/unavailable. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.0.1: Configure firewall before pcs commands. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/high_availability/tasks/main.yml
+++ b/roles/high_availability/tasks/main.yml
@@ -206,4 +206,18 @@
       when: high_availability_stonith is defined and high_availability_stonith
       notify: command █ Push HA configuration
 
+    - name: command █ Disable stonith if it is not configured
+      command: "pcs -f {{ high_availability_cib_file_path }} property set stonith-enabled=false"
+      when:
+        - (pcs_property.stdout_lines | select("match", ".*stonith-enabled:\\sfalse.*") | list | length) == 0
+        - high_availability_stonith is not defined or not high_availability_stonith
+      notify: command █ Push HA configuration
+
+    - name: command █ Enable stonith if it has been properly configured
+      command: "pcs -f {{ high_availability_cib_file_path }} property set stonith-enabled=true"
+      when:
+        - (pcs_property.stdout_lines | select("match", ".*stonith-enabled:\\strue.*") | list | length) == 0
+        - high_availability_stonith is defined and high_availability_stonith
+      notify: command █ Push HA configuration
+
 - meta: flush_handlers


### PR DESCRIPTION
This PR is to allow a HA cluster to run without STONITH configuration available (empty or missing `high_availability_stonith` variable in inventory).
Defining the `high_availability_stonith` variable and running the role will enable STONITH if it was disabled.