### PR TITLE
Fix: Create users for karma and alertmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## 1.0.2 - Next release
 
+### Updated roles
+
+  - prometheus
+    - ensure karma and alertmanager users are created (#46)
+
 ### New roles
 
   - loki. Owner: @neilmunday
 
-## 1.0.1 - Next release
+## 1.0.1
 
 ### Updated roles
 
@@ -19,7 +24,7 @@
     - correct logical operator to run local registry. (#33)
     - quotes in lists of registries. (#34)
 
-## 1.0.0 - Next release
+## 1.0.0
 
 ### New roles
 

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -18,6 +18,10 @@ prometheus_server_snmp_exporter_host: localhost
 
 prometheus_server_prometheus_user_gid: 909
 prometheus_server_prometheus_user_uid: 909
+prometheus_server_alertmanager_user_gid: 910
+prometheus_server_alertmanager_user_uid: 910
+prometheus_server_karma_user_gid: 911
+prometheus_server_karma_user_uid: 911
 
 prometheus_server_launch_parameters: |
   --config.file /etc/prometheus/prometheus.yml \

--- a/roles/prometheus/tasks/server_alertmanager.yml
+++ b/roles/prometheus/tasks/server_alertmanager.yml
@@ -1,20 +1,21 @@
 ---
-- name: Package █ Install alertmanager package
-  package:
-    name: alertmanager
-    state: present
-
 - name: group █ Add alertmanager group
   group:
    name: alertmanager
+   gid: "{{ prometheus_server_alertmanager_user_gid }}"
    state: present
 
 - name: user █ Add alertmanager user
   user:
     name: alertmanager
     shell: /bin/false
+    uid: "{{ prometheus_server_alertmanager_user_gid }}"
     group: alertmanager
-    system: yes
+    state: present
+
+- name: Package █ Install alertmanager package
+  package:
+    name: alertmanager
     state: present
 
 - name: template █ Generate alertmanager service file

--- a/roles/prometheus/tasks/server_alertmanager.yml
+++ b/roles/prometheus/tasks/server_alertmanager.yml
@@ -9,7 +9,7 @@
   user:
     name: alertmanager
     shell: /bin/false
-    uid: "{{ prometheus_server_alertmanager_user_gid }}"
+    uid: "{{ prometheus_server_alertmanager_user_uid }}"
     group: alertmanager
     state: present
 

--- a/roles/prometheus/tasks/server_alertmanager.yml
+++ b/roles/prometheus/tasks/server_alertmanager.yml
@@ -4,6 +4,19 @@
     name: alertmanager
     state: present
 
+- name: group █ Add alertmanager group
+  group:
+   name: alertmanager
+   state: present
+
+- name: user █ Add alertmanager user
+  user:
+    name: alertmanager
+    shell: /bin/false
+    group: alertmanager
+    system: yes
+    state: present
+
 - name: template █ Generate alertmanager service file
   template:
     src: alertmanager.service.j2

--- a/roles/prometheus/tasks/server_karma.yml
+++ b/roles/prometheus/tasks/server_karma.yml
@@ -4,6 +4,19 @@
     name: karma
     state: present
 
+- name: group █ Add karma group
+  group:
+   name: karma
+   state: present
+
+- name: user █ Add karma user
+  user:
+    name: karma
+    shell: /bin/false
+    group: karma
+    system: yes
+    state: present
+
 - name: template █ Generate karma service file
   template:
     src: karma.service.j2

--- a/roles/prometheus/tasks/server_karma.yml
+++ b/roles/prometheus/tasks/server_karma.yml
@@ -1,20 +1,21 @@
 ---
-- name: Package █ Install karma package
-  package:
-    name: karma
-    state: present
-
 - name: group █ Add karma group
   group:
    name: karma
+   gid: "{{ prometheus_server_karma_user_gid }}"
    state: present
 
 - name: user █ Add karma user
   user:
     name: karma
     shell: /bin/false
+    uid: "{{ prometheus_server_karma_user_uid }}"
     group: karma
-    system: yes
+    state: present
+
+- name: Package █ Install karma package
+  package:
+    name: karma
     state: present
 
 - name: template █ Generate karma service file


### PR DESCRIPTION
Karma and alertmanager users used to be created by their respective rpms. No more.
This fix ensure users are present with the role.