### PR TITLE
Fix: podman - Use slirp4netns to avoid error with HA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.6
+
+### Updated roles
+
+  - podman:
+    - Use slirp4netns to avoid error with HA (#65)
+
 ## 1.5.1
 
 ### Updated roles

--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -118,3 +118,8 @@ podman_local_registry_group: "root"
 ## License and Author
 
 * Author:: @strus38
+
+## Changelog
+
+* 1.0.1: Use slirp4netns to avoid error with HA (#65). Giacomo Mc Evoy <gino.mcevoy@gmail.com>
+* 1.0.0: Role creation. @strus38

--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -14,11 +14,13 @@ This role is compatible with HA clusters:
 
 ## Requirements
 
-Ansible 2.7 or higher is required for defaults/main/*.yml to work correctly.
+Ansible 2.7 or higher is required for `defaults/main/*.yml` to work correctly.
 
 ## Known Limitations
 
-When firewalld is running, containers deployed with podman may lose connectivity if the firewall rules are reloaded with the `firewall-cmd --reload` command, due to non-persistent rules added by podman being lost. As a workaround, the following command should be used after reloading the firewall, it will restore container connectivity without having to re-deploy the containers:
+- When firewalld is running, containers deployed with podman may lose connectivity if the firewall rules are reloaded with the `firewall-cmd --reload` command, due to non-persistent rules added by podman being lost. As a workaround, the following command should be used after reloading the firewall, it will restore container connectivity without having to re-deploy the containers:
+
+- There is an issue between podman and pacemaker: if a privileged container is managed by a systemd service (e.g. using `podman generate systemd` command), the container may lose connectivity the first time that the service is started by pacemaker. To avoid this issue, use the user-mode networking for unprivileged containers, by adding `--net=slip4netns` to the `podman run` command in the service definition. For reference, see the template of the registry service.
 
 ```
 podman network reload --all

--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -123,5 +123,5 @@ podman_local_registry_group: "root"
 
 ## Changelog
 
-* 1.0.1: Use slirp4netns to avoid error with HA (#65). Giacomo Mc Evoy <gino.mcevoy@gmail.com>
+* 1.0.1: Use slirp4netns to avoid error with HA. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.0.0: Role creation. @strus38

--- a/roles/podman/templates/registry.service.j2
+++ b/roles/podman/templates/registry.service.j2
@@ -9,7 +9,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=62
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --sdnotify=conmon --cgroups=no-conmon --rm --replace --name=registry --privileged -p 5000:{{ podman_local_registry_port }} -v /var/lib/registry:{{ podman_local_registry_dir }} {{ podman_registry_container }}:{{ podman_registry_container_tag }}
+ExecStart=/usr/bin/podman run --net=slirp4netns --cidfile=%t/%n.ctr-id --sdnotify=conmon --cgroups=no-conmon --rm --replace --name=registry --privileged -p 5000:{{ podman_local_registry_port }} -v /var/lib/registry:{{ podman_local_registry_dir }} {{ podman_registry_container }}:{{ podman_registry_container_tag }}
 ExecStop=/usr/bin/podman stop -t 2 --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify

--- a/roles/podman/vars/main.yml
+++ b/roles/podman/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-podman_role_version: 1.0.0
+podman_role_version: 1.0.1


### PR DESCRIPTION
Previous PR #38 mentioned an issue with podman containers and firewall, that results in a "Connection refused" error. While the explanation in the PR is correct (containers lose connectivity after a firewall reload), there is another situation that the error happens: after pacemaker begins to manage the systemd service for the first time in a High Availability scenario. We have reproduced this issue consistently with VMs, but it only happened the first time the service is started by pacemaker on each node.

This PR implements a fix proposed in the previous PR, to use the slirp4netns user-mode networking for the systemd service of the private registry provided by the podman role. This solution is used for unprivileged containers by default, but it can also be used for privileged containers. We have not found any downsides of using slirp4netns in this and other privileged container services.

Edit: clarify that the fix is for the registry service