### PR TITLE
Feat: high_availability: Allow specification of name of the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.6
+
+### Updated roles
+
+  - high_availability:
+    - Allow specification of name of the cluster (#66)
+
 ## 1.5.1
 
 ### Updated roles

--- a/roles/high_availability/README.md
+++ b/roles/high_availability/README.md
@@ -68,6 +68,7 @@ Then in `inventory/group_vars/ha_cluster` folder, create a file
 `ha_parameters.yml` with the following variables, tuned to your needs:
 
 ```yaml
+high_availability_cluster_name: ha_cluster  # name of the pacemaker/corosync cluster
 high_availability_cluster_nodes:
   - name: ha1             # Hostname of the HA cluster nodes
     addrs:                # List of addresses to be used for HA ring (allow multiple rings for redundancy)
@@ -104,6 +105,7 @@ to secure HA cluster in case one network fail:
 So for example here:
 
 ```yaml
+high_availability_cluster_name: ha_cluster
 high_availability_cluster_nodes:
   - name: ha1             # Hostname of the HA cluster nodes
     addrs:                # List of addresses to be used for HA ring (allow multiple rings for redundancy)
@@ -582,6 +584,7 @@ not present. Then in HA resources, declare the following:
 
 ## 5. Changelog
 
+* 1.0.5: Allow specification of name of the cluster. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.0.4: Allows order constraint between resource groups. Thiago Cardozo <thiago.cardozo@yahoo.com.br>
 * 1.0.3: Fix use of unencrypted password of hacluster user. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.0.2: Enable/disable STONITH when configuration is available/unavailable. Giacomo Mc Evoy <gino.mcevoy@gmail.com>

--- a/roles/high_availability/defaults/main.yml
+++ b/roles/high_availability/defaults/main.yml
@@ -1,4 +1,5 @@
 high_availability_cib_file_path: /root/ha_config.ansible.xml
+high_availability_ha_cluster_name: ha_cluster
 high_availability_ha_cluster_password: root
 high_availability_ha_cluster_password_sha512: $6$M3crarMVoUV3rALd$ZTre2CIyss7zOb4lkLoG23As9OAkYPw2BM88Y1F43n8CCyV5XWwAYEwBOrS8bcCBIMjIPdJG.ndOfzWyAVR4j0
 

--- a/roles/high_availability/tasks/main.yml
+++ b/roles/high_availability/tasks/main.yml
@@ -64,7 +64,7 @@
       ignore_errors: yes
 
     - name: command █ Register reference node
-      ansible.builtin.command: "pcs cluster setup ha_cluster {{ item.name }} {% for addr in item.addrs %}addr={{ addr }} {% endfor %}"
+      ansible.builtin.command: "pcs cluster setup {{ high_availability_cluster_name }} {{ item.name }} {% for addr in item.addrs %}addr={{ addr }} {% endfor %}"
       loop: "{{ high_availability_cluster_nodes }}"
       when:
         - ( corosync_known_hosts.stdout_lines | select("match", ".*"+high_availability_reference_node+".*") | list | length ) < 1

--- a/roles/high_availability/vars/main.yml
+++ b/roles/high_availability/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-high_availability_role_version: 1.0.4
+high_availability_role_version: 1.0.5


### PR DESCRIPTION
This PR is to add a new feature to high_availability role: to be able to specify the name of the corosync/pacemaker cluster. The default is "ha_cluster" which was the hard-coded value.