### PR TITLE
Fix usage of slurm_extra_nodes_parameters.

### DIFF
--- a/roles/slurm/templates/slurm.conf.j2
+++ b/roles/slurm/templates/slurm.conf.j2
@@ -78,7 +78,7 @@ JobAcctGatherType=jobacct_gather/linux
         {% set nodes_parameters = nodes_parameters + ' RealMemory=' + (buffer.memory|string) %}
     {% endif %}
     {% if buffer.slurm_extra_nodes_parameters is defined and buffer.slurm_extra_nodes_parameters is not none %}
-        {% set nodes_parameters = nodes_parameters + slurm_extra_nodes_parameters %}
+        {% set nodes_parameters = nodes_parameters + ' ' + buffer.slurm_extra_nodes_parameters %}
     {% endif %}
 NodeName={{ groups[computes_group] | nodeset }} {{ nodes_parameters }}
 


### PR DESCRIPTION
As there is no slurm_extra_nodes_parameters variable on the slurm.conf.j2 template, the role fails:

TASK [template █ Generate configuration files in /etc/slurm] ***********************************************************************
Sunday 29 May 2022  07:19:33 +0200 (0:00:00.760)       0:00:08.381 ************
failed: [login1] (item=slurm.conf) => changed=false
  ansible_loop_var: item
  item: slurm.conf
  msg: 'AnsibleUndefinedVariable: ''slurm_extra_nodes_parameters'' is undefined'

Added as well one space char so the slurm_extra_nodes_parameters and the default parameters get separated.