### PR TITLE
Add high_availability_autostart variable

### DIFF
--- a/roles/high_availability/tasks/main.yml
+++ b/roles/high_availability/tasks/main.yml
@@ -86,7 +86,7 @@
 - name: service █ Enable and start cluster
   ansible.builtin.service:
     name: "{{ item }}"
-    enabled: true
+    enabled: "{{ high_availability_autostart |  default(false) }}"
     state: started
   loop:
     - corosync


### PR DESCRIPTION
Adding high_availability_autostart so the user can control this behavior.

Also defining default behavior to be not enabling the HA resources (corosync & pacemaker) automatically.

I think that maybe we should not want the default behavior of the HA of the node is to start automatically on boot, because if we have some specific issue with the node that is leading to fence, It may get into some kind of fence-loop ( depending on the stickness/score configurations of the related resources as well ). So the main behavior maybe should be: "error"-> fence -> some kind of support evaluation -> bring node back to cluster. 

I may be wrong about this default behavior, just starting some topics for us to discuss, the variable I think we should have anyways though.