### PR TITLE
Remove preffers requirement for stonith

### DIFF
--- a/roles/high_availability/tasks/main.yml
+++ b/roles/high_availability/tasks/main.yml
@@ -204,7 +204,7 @@
       failed_when:
         - cmd.rc != 0
         - "'already exists' not in cmd.stderr"
-      when: high_availability_stonith is defined and high_availability_stonith
+      when: high_availability_stonith is defined and high_availability_stonith.prefers is defined
       notify: command █ Push HA configuration
 
     - name: command █ Set stonith avoids constraint


### PR DESCRIPTION
Removed the prefers requirements for stonith.

I think we want to avoid the stonith resource to be on the same node as the resource is created to fence, but it will only be accomplished by the avoids constraint, so we maybe should remove the obligation to set it for the stonith resource.

Ref:
A value of INFINITY for score in a pcs constraint location rsc prefers command indicates that the resource will prefer that node if the node is available, but does not prevent the resource from running on another node if the specified node is unavailable.

A value of INFINITY for score in a pcs constraint location rsc avoids command indicates that the resource will never run on that node, even if no other node is available. This is the equivalent of setting a pcs constraint location add command with a score of -INFINITY.

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_high_availability_clusters/index#:~:text=A%20node%E2%80%99s%20name-,score,-Positive%20integer%20value