### PR TITLE
fix bug on generating gres.conf on nodes without GPU

### DIFF
--- a/roles/slurm/tasks/compute_configfull.yml
+++ b/roles/slurm/tasks/compute_configfull.yml
@@ -10,5 +10,16 @@
     - template
   loop:
     - slurm.conf
+   
+- name: "template █ Generate gres.conf in {{ slurm_home_path }}"
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "{{ slurm_home_path }}/{{ item }}"
+    owner: slurm
+    group: slurm
+    mode: 0644
+  tags:
+    - template
+  loop:
     - gres.conf
-    
+  when: slurm_gresTypes is defined and slurm_gresTypes == 'gpu' and ep_hardware['gpu'] is defined 


### PR DESCRIPTION
nodes without declared GPU on equipament_profile.yml were getting the following error:

TASK [template █ Generate configuration files in /etc/slurm] *******************************************
Sunday 21 August 2022  23:55:58 -0300 (0:00:00.037)       0:00:15.346 ********* 
changed: [c001] => (item=slurm.conf)
failed: [c001] (item=gres.conf) => changed=false 
  ansible_loop_var: item
  item: gres.conf
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''gpu'''
  
  This commit fixes it.
