### PR TITLE
roles/grafana: fix admin password check

### DIFF
--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -144,6 +144,7 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
+* 2.0.5: Fix grafana-cli with the use of homepath. Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 2.0.4: Fix log permissions and firewall check. Thiago Cardozo <thiago.cardozo@yahoo.com.br>
 * 2.0.3: Update to fully qualified module name. Matthieu Isoard
 * 2.0.2: Add OpenSUSE support. Neil Munday <neil@mundayweb.com>

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -251,5 +251,3 @@ grafana_environment: {}
 grafana_panels: {}
 #  disable_sanitize_html: false
 #  enable_alpha: false
-
-grafana_homepath: /usr/share/grafana

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -251,3 +251,5 @@ grafana_environment: {}
 grafana_panels: {}
 #  disable_sanitize_html: false
 #  enable_alpha: false
+
+grafana_homepath: /usr/share/grafana

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -102,7 +102,7 @@
     - plugins
 
 - name: grafana █ Ensure password is set to the one in the role variables
-  ansible.builtin.command: "grafana-cli admin reset-admin-password {{ grafana_security.admin_password }}"
+  ansible.builtin.command: "grafana-cli --homepath /usr/share/grafana admin reset-admin-password {{ grafana_security.admin_password }}"
   changed_when: false
   no_log: true
   register: grafana_cli_var

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -102,7 +102,7 @@
     - plugins
 
 - name: grafana █ Ensure password is set to the one in the role variables
-  ansible.builtin.command: "grafana-cli --homepath /usr/share/grafana admin reset-admin-password {{ grafana_security.admin_password }}"
+  ansible.builtin.command: "grafana-cli --homepath {{ grafana_homepath }} admin reset-admin-password {{ grafana_security.admin_password }}"
   changed_when: false
   no_log: true
   register: grafana_cli_var

--- a/roles/grafana/vars/Debian.yml
+++ b/roles/grafana/vars/Debian.yml
@@ -5,3 +5,5 @@ grafana_services_to_start:
   - grafana-server
 grafana_firewall_services_to_add:
   - grafana
+
+grafana_homepath: /usr/share/grafana

--- a/roles/grafana/vars/RedHat.yml
+++ b/roles/grafana/vars/RedHat.yml
@@ -5,3 +5,5 @@ grafana_services_to_start:
   - grafana-server
 grafana_firewall_services_to_add:
   - grafana
+
+grafana_homepath: /usr/share/grafana

--- a/roles/grafana/vars/Suse.yml
+++ b/roles/grafana/vars/Suse.yml
@@ -5,3 +5,5 @@ grafana_services_to_start:
   - grafana-server
 grafana_firewall_services_to_add:
   - grafana
+
+grafana_homepath: /usr/share/grafana

--- a/roles/grafana/vars/Ubuntu.yml
+++ b/roles/grafana/vars/Ubuntu.yml
@@ -5,3 +5,5 @@ grafana_services_to_start:
   - grafana-server
 grafana_firewall_services_to_add:
   - grafana
+
+grafana_homepath: /usr/share/grafana

--- a/roles/grafana/vars/main.yml
+++ b/roles/grafana/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-grafana_role_version: 2.0.4
+grafana_role_version: 2.0.5


### PR DESCRIPTION
Looks like grafana-cli command needs `--homepath` to work properly.